### PR TITLE
Fix DBC usage for International dbc

### DIFF
--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -836,7 +836,7 @@ bool AuthSession::VerifyVersion(uint8 const* a, int32 aLength, Warhead::Crypto::
     if (!sConfigMgr->GetOption<bool>("StrictVersionCheck", false))
         return true;
 
-    Warhead::Crypto::SHA1::Digest zeros = { };
+    Warhead::Crypto::SHA1::Digest zeros{};
     Warhead::Crypto::SHA1::Digest const* versionHash = nullptr;
 
     if (!isReconnect)

--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -837,7 +837,7 @@ bool AuthSession::VerifyVersion(uint8 const* a, int32 aLength, Warhead::Crypto::
         return true;
 
     Warhead::Crypto::SHA1::Digest zeros{};
-    Warhead::Crypto::SHA1::Digest const* versionHash = nullptr;
+    Warhead::Crypto::SHA1::Digest const* versionHash{ nullptr };
 
     if (!isReconnect)
     {

--- a/src/server/authserver/Server/AuthSession.cpp
+++ b/src/server/authserver/Server/AuthSession.cpp
@@ -836,7 +836,7 @@ bool AuthSession::VerifyVersion(uint8 const* a, int32 aLength, Warhead::Crypto::
     if (!sConfigMgr->GetOption<bool>("StrictVersionCheck", false))
         return true;
 
-    Warhead::Crypto::SHA1::Digest zeros;
+    Warhead::Crypto::SHA1::Digest zeros = { };
     Warhead::Crypto::SHA1::Digest const* versionHash = nullptr;
 
     if (!isReconnect)

--- a/src/server/scripts/Commands/cs_misc.cpp
+++ b/src/server/scripts/Commands/cs_misc.cpp
@@ -549,9 +549,9 @@ public:
         }
 
         handler->PSendSysMessage(LANG_MAP_POSITION,
-                                 object->GetMapId(), (mapEntry ? mapEntry->name[handler->GetSessionDbcLocale()] : "<unknown>"),
-                                 zoneId, (zoneEntry ? zoneEntry->area_name[handler->GetSessionDbcLocale()] : "<unknown>"),
-                                 areaId, (areaEntry ? areaEntry->area_name[handler->GetSessionDbcLocale()] : "<unknown>"),
+                                 object->GetMapId(), (mapEntry ? mapEntry->name[handler->GetSessionDbLocaleIndex()] : "<unknown>"),
+                                 zoneId, (zoneEntry ? zoneEntry->area_name[handler->GetSessionDbLocaleIndex()] : "<unknown>"),
+                                 areaId, (areaEntry ? areaEntry->area_name[handler->GetSessionDbLocaleIndex()] : "<unknown>"),
                                  object->GetPhaseMask(),
                                  object->GetPositionX(), object->GetPositionY(), object->GetPositionZ(), object->GetOrientation(),
                                  cell.GridX(), cell.GridY(), cell.CellX(), cell.CellY(), object->GetInstanceId(),


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:
-  Fix localized strings taken from dbc

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

enUS client:

![изображение](https://user-images.githubusercontent.com/25766571/163668718-f417b213-b405-4bea-9702-308949fc4cd3.png)

ruRU client

![изображение](https://user-images.githubusercontent.com/25766571/163668723-f8b85aff-e1c4-4751-af54-7c3ca188afb4.png)


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Make sure your server uses dbc with several localizations, (for ex.: not only ruRU or only enUS)
2. Using client with different locales login to world and type `.gps`
3. Map, area, zone names must be shown according to client localization

<!-- If you intend to contribute repeatedly to our project, it is a good idea to join our discord channel. We set ranks for our contributors and give them access to special resources or knowledge: https://discord.com/invite/DasJqPba)
     Do not remove the instructions below about testing, they will help users to test your PR -->
## How to Test AzerothCore PRs
 
When a PR is ready to be tested, it will be marked as **[WAITING TO BE TESTED]**.

You can help by testing PRs and writing your feedback here on the PR's page on GitHub. Follow the instructions here:

http://www.azerothcore.org/wiki/How-to-test-a-PR

**REMEMBER**: when testing a PR that changes something **generic** (i.e. a part of code that handles more than one specific thing), the tester should not only check that the PR does its job (e.g. fixing spell XXX) but **especially** check that the PR does not cause any regression (i.e. introducing new bugs).

**For example**: if a PR fixes spell X by changing a part of code that handles spells X, Y, and Z, we should not only test X, but **we should test Y and Z as well**.
